### PR TITLE
Support Fill In and Relate with Public access forms.

### DIFF
--- a/Client Side Global Functions/FillinAndRelateForm.js
+++ b/Client Side Global Functions/FillinAndRelateForm.js
@@ -7,49 +7,47 @@
     Parameters:    The following represent variables passed into the function:  
                     templateId: Id of form template to fill in and relate to the current form instance
                     fieldMappings: array of objects containing: sourceFieldName, sourceFieldValue, targetFieldName
-                    launchType: 'self' launches the target form in the same window - 'blank' launches the target form in a new window.
+                    launchType: 'self' launches the target form in the same window.
                     Mapped field array example for build fieldMappings
                      var mappedField = {};
                      mappedField.sourceFieldName = 'providerId';
-                     mappedField.sourceFieldValue = VV.Form.GetFieldValue('providerId');
+                     mappedField.sourceFieldValue = VV.Form.GetFieldValue('Provider ID');
                      mappedField.targetFieldName = 'Provider ID';
                      fieldMappings.push(mappedField);
                    
     Return Value:  The following represents the value being returned from this function:
                             
-    Date of Dev: 06/01/2017   
-    Last Rev Date: 06/20/2022
+    Date of Dev:   
+    Last Rev Date: 08/21/2019
     Revision Notes:
     06/01/2017 - Tod Olsen: Initial creation of the business process. 
     01/03/2019 - Kendra Austin: Add launchType for option to redirect in the current window instead of opening new. 
     08/21/2019 - Jason Hatch:  Added mechanism to encode the URL so that it will change characters like a + sign in the email into an encoded value.
-    06/20/2022 - Franco Petosa Ayala: Update to ES6.
-                                      Changed the conditional structure (setting the launch mode) to improve code readability.
+    11/19/2020 - Rocky: Add encodeURIComponent to handle special characters https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
 */
 
 //Opens using new window that is popup blocker safe as long as this function is called from a DOM event handler
-let popupUrl = `${VV.BaseURL}form_details?formid=${templateId}&RelateForm=${VV.Form.DataID}&IsRelate=true&hidemenu=true`;
 
-fieldMappings.forEach( fieldMapping => {
+var popupUrl = VV.BaseURL + "form_details?formid=" + templateId + "&RelateForm=" + VV.Form.DataID + "&IsRelate=true&hidemenu=true";
+
+fieldMappings.forEach(function (fieldMapping) {
     if (fieldMapping) {
-        //Concatenates the params to the url
-        popupUrl += `&${fieldMapping.targetFieldName}=${fieldMapping.sourceFieldValue}`;
+        popupUrl += "&" + encodeURIComponent(fieldMapping.targetFieldName) + "=" + encodeURIComponent(fieldMapping.sourceFieldValue);
     }
 }, this);
 
 //Determine action by the window that is launched.
-let launchMode = '';
-if ( typeof launchType != 'undefined' && launchType.toLowerCase() == "self") {
-    launchMode = "_self";
-} else{
-    launchMode = "_blank";
+var launchMode = "_blank";
+if (launchType != null && launchType != undefined) {
+    if (launchType.toLowerCase() == "self") {
+        launchMode = "_self";
+    }
 }
-
-popupUrl = popupUrl.replace('+', '%2B');
 
 if (launchMode == '_self') {
     VV.Form.ShowLoadingPanel();
     window.location = popupUrl;
-} else {
-    VV.Form.LastChildWindow = ShowPopUp(popupUrl, "", 900, 900, "yes", "yes", "no", "no", "no");
+}
+else {
+    VV.Form.LastChildWindow = window.open(popupUrl);
 }

--- a/Client Side Global Functions/FillinAndRelateForm.js
+++ b/Client Side Global Functions/FillinAndRelateForm.js
@@ -28,7 +28,13 @@
 
 //Opens using new window that is popup blocker safe as long as this function is called from a DOM event handler
 
-var popupUrl = VV.BaseURL + "form_details?formid=" + templateId + "&RelateForm=" + VV.Form.DataID + "&IsRelate=true&hidemenu=true";
+let baseURL = VV.BaseURL;
+
+if (VV.Form.FormUserID === 'Public') {
+    baseURL = baseURL.replace('/app/', '/public/');
+}
+
+let popupUrl = `${baseURL}form_details?formid=${templateId}&RelateForm=${VV.Form.DataID}&IsRelate=true&hidemenu=true`;
 
 fieldMappings.forEach(function (fieldMapping) {
     if (fieldMapping) {


### PR DESCRIPTION
> [!CAUTION]
> Some further reconciliation may be needed as it appears the version of this function in this repo and the version used in VV5Dev for PAELS have diverged. It seems there was a change made in 2020 in VV5Dev that never made it to this repo, and a change made in 2022 in this repo that never made it to VV5Dev.

Currently, the FillInAndRelate form function does not support running from a form using the public access link. This is because `VV.BaseURL` uses `/app/` in its path whereas the public URLs use `/public/` instead.

Here is a quick screen recording of the current behavior, trying to fill in and relate a form while using the public access link:

https://github.com/VisualVault/VisualVault-Implementation-Library/assets/160517498/811bf103-1799-4cbf-b881-59f59c5519f2

Notice how the URL opened uses `/app/` in the path, and thus I am told I don't have permission and am asked to log in, despite the fact that this form does have public access.

Here is another quick screen recording where I swap out the `FillinAndRelateForm` global function with my proposed version:

https://github.com/VisualVault/VisualVault-Implementation-Library/assets/160517498/a28ee70b-9182-42a6-b28c-23c8da951cbd

With this version of the function, `FillinAndRelateForm` detects that we are accessing the form as the public user, and replaces `/app/` with `/public/` in the base URL when constructing the URL to open. This change allows the second form to open in fill and relate mode with the public user.

This change should not impact the functionality of the global function when *not* accessing the form as the public user, because FormUserID will not equal 'Public' and therefore VV.BaseURL will be passed through as it was before.